### PR TITLE
Fix win/loss calculation in player search

### DIFF
--- a/public/js/data-models.js
+++ b/public/js/data-models.js
@@ -128,8 +128,8 @@ class PlayerProfile {
     calculateRecentForm() {
         if (!this.recentMatches || this.recentMatches.length === 0) return [];
         
-        return this.recentMatches.slice(0, 10).map(match => 
-            match.match_result === 1 ? 'W' : 'L'
+        return this.recentMatches.slice(0, 10).map(match =>
+            Number(match.match_result) === 1 ? 'W' : 'L'
         );
     }
 

--- a/public/js/deadlock-api-service.js
+++ b/public/js/deadlock-api-service.js
@@ -543,7 +543,7 @@ class DeadlockAPIService {
             const kills = match.player_kills || match.kills || 0;
             const deaths = match.player_deaths || match.deaths || 0;
             const assists = match.player_assists || match.assists || 0;
-            const matchResult = match.match_result;
+            const matchResult = Number(match.match_result);
             const heroId = match.hero_id;
             
             // Win/loss tracking

--- a/public/js/player-search.js
+++ b/public/js/player-search.js
@@ -245,6 +245,8 @@ class PlayerSearch {
                     start_time: match.start_time
                 });
                 
+                const resultValue = Number(match.match_result);
+
                 return {
                     matchId: match.match_id,
                     heroId: match.hero_id,
@@ -253,7 +255,7 @@ class PlayerSearch {
                     kills: match.player_kills || 0,
                     deaths: match.player_deaths || 0,
                     assists: match.player_assists || 0,
-                    result: match.match_result === 1 ? 'win' : 'loss',
+                    result: resultValue === 1 ? 'win' : 'loss',
                     startTime: new Date(match.start_time * 1000).toISOString(),
                     duration: match.match_duration_s || 0,
                     playerDamage: 0, // Not available in this endpoint


### PR DESCRIPTION
## Summary
- normalize `match_result` as a number when building player recent match data
- ensure win/loss stats are computed with numeric match results

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6883cbaab6dc83218fa6a00f9599b158